### PR TITLE
Add user details to sign in flow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,7 @@ import { CheckoutPage } from './components/CheckoutPage';
 import { OrderConfirmationPage } from './components/OrderConfirmationPage';
 import { ProductDetailPage } from './components/ProductDetailPage';
 import { GuestLoginPage } from './components/GuestLoginPage';
-import { Page, Product, CartItem, ShippingInfo, Order } from './types';
+import { Page, Product, CartItem, ShippingInfo, Order, UserProfile } from './types';
 import { FAQPage } from './components/FAQPage';
 import { BestsellerPage } from './components/BestsellerPage';
 import { NewArrivalsPage } from './components/NewArrivalsPage';
@@ -42,6 +42,7 @@ const App: React.FC = () => {
   const [isGuestLoggedIn, setIsGuestLoggedIn] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -151,7 +152,8 @@ const App: React.FC = () => {
     window.scrollTo(0, 0);
   }
   
-  const handleLoginAsGuest = () => {
+  const handleLoginAsGuest = (profile: UserProfile) => {
+    setUserProfile(profile);
     setIsGuestLoggedIn(true);
     setCurrentPage('profile');
     window.scrollTo(0, 0);
@@ -201,7 +203,7 @@ const App: React.FC = () => {
       case 'cart':
         return <CartPage cartItems={cartItems} onUpdateQuantity={handleUpdateCartQuantity} onRemoveItem={handleRemoveFromCart} onNavigate={handleNavigate} />;
       case 'profile':
-        return <ProfilePage />;
+        return <ProfilePage userProfile={userProfile} />;
       case 'search':
         return <SearchPage {...pageProps} />;
        case 'checkout':

--- a/components/GuestLoginPage.tsx
+++ b/components/GuestLoginPage.tsx
@@ -1,26 +1,89 @@
 
-import React from 'react';
+import React, { useState } from 'react';
+import { UserProfile } from '../types';
 
 interface GuestLoginPageProps {
-  onGuestLogin: () => void;
+  onGuestLogin: (profile: UserProfile) => void;
 }
 
 export const GuestLoginPage: React.FC<GuestLoginPageProps> = ({ onGuestLogin }) => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onGuestLogin({
+      name: name.trim() || 'Guest User',
+      email: email.trim(),
+      phone: phone.trim() || undefined,
+    });
+  };
+
+  const isFormValid = email.trim().length > 0;
+
   return (
     <div className="bg-[#5c1f2b] py-20 animate-fade-in">
       <div className="container mx-auto px-6 flex justify-center">
         <div className="w-full max-w-md">
           <div className="bg-[#4a1922] border border-white/10 rounded-lg shadow-md p-8">
-            <h1 className="text-3xl font-serif text-center text-white mb-4">Welcome</h1>
-            <p className="text-center text-white/80 mb-8">Continue as a guest to manage your profile.</p>
+            <h1 className="text-3xl font-serif text-center text-white mb-4">Welcome Back</h1>
+            <p className="text-center text-white/80 mb-8">
+              Sign in with your details to personalize your experience.
+            </p>
 
-            <button
-              onClick={onGuestLogin}
-              className="w-full bg-white text-[#5c1f2b] font-bold py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors"
-            >
-              Continue as Guest
-            </button>
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div>
+                <label className="block text-sm font-medium text-white/80 mb-1" htmlFor="name">
+                  Full Name
+                </label>
+                <input
+                  id="name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Priya Sharma"
+                  className="w-full px-4 py-3 rounded-lg bg-white/10 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white/40 border border-white/10"
+                />
+              </div>
 
+              <div>
+                <label className="block text-sm font-medium text-white/80 mb-1" htmlFor="email">
+                  Email Address
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="priya@example.com"
+                  required
+                  className="w-full px-4 py-3 rounded-lg bg-white/10 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white/40 border border-white/10"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-white/80 mb-1" htmlFor="phone">
+                  Phone Number
+                </label>
+                <input
+                  id="phone"
+                  type="tel"
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
+                  placeholder="+91 98765 43210"
+                  className="w-full px-4 py-3 rounded-lg bg-white/10 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white/40 border border-white/10"
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={!isFormValid}
+                className="w-full bg-white text-[#5c1f2b] font-bold py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Continue to My Account
+              </button>
+            </form>
           </div>
         </div>
       </div>

--- a/components/ProfilePage.tsx
+++ b/components/ProfilePage.tsx
@@ -1,8 +1,17 @@
 
 import React from 'react';
 import { UserIcon } from './icons/UserIcon';
+import { UserProfile } from '../types';
 
-export const ProfilePage: React.FC = () => {
+interface ProfilePageProps {
+  userProfile: UserProfile | null;
+}
+
+export const ProfilePage: React.FC<ProfilePageProps> = ({ userProfile }) => {
+  const displayName = userProfile?.name?.trim() || 'Guest User';
+  const displayEmail = userProfile?.email?.trim() || 'guest@example.com';
+  const displayPhone = userProfile?.phone?.trim();
+
   return (
     <div className="bg-[#5c1f2b] py-20 animate-fade-in">
       <div className="container mx-auto px-6">
@@ -23,11 +32,15 @@ export const ProfilePage: React.FC = () => {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
                     <label className="text-sm font-medium text-white/70">Name</label>
-                    <p className="font-semibold">Guest User</p>
+                    <p className="font-semibold">{displayName}</p>
                   </div>
                   <div>
                     <label className="text-sm font-medium text-white/70">Email</label>
-                    <p className="font-semibold">guest@example.com</p>
+                    <p className="font-semibold">{displayEmail}</p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-white/70">Phone</label>
+                    <p className="font-semibold">{displayPhone || 'Not provided'}</p>
                   </div>
                 </div>
                  <button className="text-white font-semibold hover:underline">Edit Details</button>

--- a/types.ts
+++ b/types.ts
@@ -13,6 +13,12 @@ export interface CartItem extends Product {
     quantity: number;
 }
 
+export interface UserProfile {
+  name: string;
+  email: string;
+  phone?: string;
+}
+
 export interface StyleAdvice {
   jewelryType: string;
   metal: string;


### PR DESCRIPTION
## Summary
- add a sign-in form that captures name, email, and phone on the guest login page
- store provided profile details in app state and render them on the profile page
- introduce a typed user profile model to support personalized account views

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abc0d87f48328b16f3e685de073ec)